### PR TITLE
Specify defaults in pyi file

### DIFF
--- a/pydustmasker/_pydustmasker.pyi
+++ b/pydustmasker/_pydustmasker.pyi
@@ -8,7 +8,7 @@ class DustMasker:
     score_threshold: int
     intervals: Sequence[tuple[int, int]]
     def __init__(
-        self, sequence: str, window_size: int, score_threshold: int
+        self, sequence: str, window_size: int = 64, score_threshold: int = 20
     ) -> None: ...
     @property
     def n_masked_bases(self) -> int: ...


### PR DESCRIPTION
Currently the default values for `window_size` and `score_threshold` aren't included in the pyi file. This causes two issues:

1. Editors don't show the default value

![current](https://github.com/user-attachments/assets/8c4375f9-f6dc-4244-adb1-52eb0e8df3f7)

2. `mypy` errors if default values aren't provided

```console
t.py:5: error: Missing positional arguments "window_size", "score_threshold" in call to "DustMasker"  [call-arg]
Found 1 error in 1 file (checked 7 source files)
```

Adding the defaults to the pyi fixes both issues:

![new](https://github.com/user-attachments/assets/07bc8f3a-a4f7-4a04-b352-1d5ab4130fb1)

```console
Success: no issues found in 7 source files
```

