### PR TITLE
Fix broken publish on new ubuntu versions

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -131,6 +131,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
       - name: Build sdist
         uses: PyO3/maturin-action@v1
         with:
@@ -149,6 +152,9 @@ jobs:
     needs: [linux, musllinux, windows, macos, sdist]
     steps:
       - uses: actions/download-artifact@v4
+      - uses: actions/setup-pytyhon@v5
+        with:
+          python-version: 3.x
       - name: Publish to PyPI
         uses: PyO3/maturin-action@v1
         env:


### PR DESCRIPTION
I just ran into [this issue](https://github.com/PyO3/maturin-action/issues/291) when publishing one of my packages, and I believe you are going to have the same problem. This change fixed the issue for me so it should you also.