### PR TITLE
a better solution for index overflow bug

### DIFF
--- a/src/sdust.rs
+++ b/src/sdust.rs
@@ -109,7 +109,7 @@ impl<'a> SymmetricDust<'a> {
                     }
                 }
             } else {
-                // suggested fix for Ambiguous nucleotides causing end ranges falling outside of the sequence 
+                // suggested fix for Ambiguous nucleotides causing end ranges falling outside of the sequence
                 // https://github.com/lh3/sdust/issues/2
                 // A `N` (or end‐of‐seq) resets the sequence:
                 // 1) flush any pending perfect intervals
@@ -117,17 +117,17 @@ impl<'a> SymmetricDust<'a> {
                     l - self.window_size + 1
                 } else {
                     0
-                }; 
+                };
                 window_start += i + 1 - l;
                 while !self.perfect_intervals.is_empty() {
                     window_start += 1;
                     self.save_masked_regions(window_start);
                 }
-        
+
                 // 2) reset the local context
                 l = 0;
                 triplet = 0;
-        
+
                 // 3) clear the sliding window and zero out all counts
                 self.window.clear();
                 self.cw.fill(0);

--- a/tests/test_pydustmasker.py
+++ b/tests/test_pydustmasker.py
@@ -41,14 +41,15 @@ def test_score_threshold():
     assert masker.score_threshold == 128
     assert masker.intervals == []
 
+
 def test_ambigious():
     # no ambigious
     seq1 = "GCCAGGCTGGCCAAGGAGATCttttttttttttttttttttttttAAGAGACCATGGCATGCACTGGCCAAGGAGATCttttttttttttttttttttttttAAGA"
     # with abigious
     seq2 = "GCCAGGCTGGCCAAGGAGATTCttttttttttttttttttttttttAAGAGCCARYCTGGCCAAGGAGANTCttttttttttttttttttttttttAAGA"
-    # with ambigious and masks 
+    # with ambigious and masks
     seq3 = "GCCAGGCTGGCCAAGGAGATTCttttttttttttttttttttttttAFGAGCCAGGCTGGCCAAGGAGANTCtttttttttnNnttttttttAAGA"
 
-    assert DustMasker(seq1, window_size=64).intervals ==  [(21, 45), (78, 102)]
+    assert DustMasker(seq1, window_size=64).intervals == [(21, 45), (78, 102)]
     assert DustMasker(seq2, window_size=64).intervals == [(22, 46), (72, 96)]
     assert DustMasker(seq3, window_size=64).intervals == [(22, 46), (72, 81), (84, 92)]

--- a/tests/test_pydustmasker.py
+++ b/tests/test_pydustmasker.py
@@ -43,11 +43,11 @@ def test_score_threshold():
 
 
 def test_ambigious():
-    # no ambigious
+    # no ambiguous
     seq1 = "GCCAGGCTGGCCAAGGAGATCttttttttttttttttttttttttAAGAGACCATGGCATGCACTGGCCAAGGAGATCttttttttttttttttttttttttAAGA"
-    # with abigious
+    # with ambiguous
     seq2 = "GCCAGGCTGGCCAAGGAGATTCttttttttttttttttttttttttAAGAGCCARYCTGGCCAAGGAGANTCttttttttttttttttttttttttAAGA"
-    # with ambigious and masks
+    # with ambiguous and masks
     seq3 = "GCCAGGCTGGCCAAGGAGATTCttttttttttttttttttttttttAFGAGCCAGGCTGGCCAAGGAGANTCtttttttttnNnttttttttAAGA"
 
     assert DustMasker(seq1, window_size=64).intervals == [(21, 45), (78, 102)]

--- a/tests/test_pydustmasker.py
+++ b/tests/test_pydustmasker.py
@@ -40,3 +40,15 @@ def test_score_threshold():
     masker = DustMasker("TACCCCCCCGCGTTTTTTT", window_size=64, score_threshold=128)
     assert masker.score_threshold == 128
     assert masker.intervals == []
+
+def test_ambigious():
+    # no ambigious
+    seq1 = "GCCAGGCTGGCCAAGGAGATCttttttttttttttttttttttttAAGAGACCATGGCATGCACTGGCCAAGGAGATCttttttttttttttttttttttttAAGA"
+    # with abigious
+    seq2 = "GCCAGGCTGGCCAAGGAGATTCttttttttttttttttttttttttAAGAGCCARYCTGGCCAAGGAGANTCttttttttttttttttttttttttAAGA"
+    # with ambigious and masks 
+    seq3 = "GCCAGGCTGGCCAAGGAGATTCttttttttttttttttttttttttAFGAGCCAGGCTGGCCAAGGAGANTCtttttttttnNnttttttttAAGA"
+
+    assert DustMasker(seq1, window_size=64).intervals ==  [(21, 45), (78, 102)]
+    assert DustMasker(seq2, window_size=64).intervals == [(22, 46), (72, 96)]
+    assert DustMasker(seq3, window_size=64).intervals == [(22, 46), (72, 81), (84, 92)]


### PR DESCRIPTION

### What’s Changed
* Flush & reset whenever b >= 4 (i.e. non-A/C/G/T) in the main scan loop:

* Drain any pending perfect_intervals through the current position.

* Clear the sliding window (VecDeque) and zero out cw, cv, rw, rv, and biggest_num_triplets.

* Reset the local run‐length (l) and rolling triplet buffer (triplet).

 No more end-of-sequence hack. The same logic now handles all ambiguous codes and true N–terminators uniformly. :)

* Test coverage: added a new test_ambiguous() in tests/test_pydustmasker.py that verifies

1.   sequences with no ambiguities
2.   sequences containing IUPAC codes (ARY, N, etc.)
3.   sequences with stray non-base characters
4.   all produce the correct low-complexity intervals.